### PR TITLE
Update gradle disable leftShift method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.arielcabib'
-version '0.1.1'
+version '0.1.2'
 
 buildscript {
     repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/src/main/java/com/arielcabib/plugin/gradle/rust/RustPlugin.groovy
+++ b/src/main/java/com/arielcabib/plugin/gradle/rust/RustPlugin.groovy
@@ -2,6 +2,7 @@ package com.arielcabib.plugin.gradle.rust
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.Exec
 
 /**
  * Created by ariel on 17/05/15.
@@ -9,26 +10,17 @@ import org.gradle.api.Project
 class RustPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.task('rustBuild') << {
-            println "Cargo building"
-            project.exec {
-                commandLine 'cargo', 'build'
-            }
+        project.tasks.create('rustBuild', Exec).configure {
+             commandLine 'cargo', 'build'
         }
 
-        project.task('rustRun') << {
-            println "Cargo running"
-            project.exec {
-                standardInput System.in
-                commandLine 'cargo', 'run'
-            }
+        project.tasks.create('rustRun', Exec).configure {
+            standardInput System.in
+            commandLine 'cargo', 'run'
         }
 
-        project.task('rustUpdate') << {
-            println "Cargo updating"
-            project.exec {
-                commandLine 'cargo', 'update'
-            }
+        project.tasks.create('rustUpdate', Exec).configure {
+             commandLine 'cargo', 'update'
         }
     }
 }


### PR DESCRIPTION
Hello, 

i have this error : 

```
* Where:
Build file 'C:\projects\cargo-with-gradle\build.gradle' line: 12

* What went wrong:
A problem occurred evaluating root project 'cargo-with-gradle'.
> Failed to apply plugin [id 'com.arielcabib.rust']
   > Could not find method leftShift() for arguments [com.arielcabib.plugin.gradle.rust.RustPlugin$_apply_closure1@76b47b3c] on task ':rustBuild' of type org.gradle.api.DefaultTask.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```

so I propose my change to create task by implicit method

Regards 